### PR TITLE
fix: pass function to `watch`

### DIFF
--- a/packages/vue3-lottie/src/vue3-lottie.vue
+++ b/packages/vue3-lottie/src/vue3-lottie.vue
@@ -257,7 +257,7 @@ export default defineComponent({
 
     // watch for changes in props
     // mainly used for the pauseAnimation prop
-    watch(props, () => {
+    watch(() => props, () => {
       // error if pauseAnimation is true and pauseOnHover is also true or playOnHover is also true
       if ((props.pauseOnHover || props.playOnHover) && !props.pauseAnimation) {
         console.error(


### PR DESCRIPTION
Causes an error:

A watch source can only be a getter/effect function, a ref, a reactive object, or an array of these types.