### PR TITLE
refactor(deps): use tree-shakeable version of lodash

### DIFF
--- a/packages/vue3-lottie/package.json
+++ b/packages/vue3-lottie/package.json
@@ -11,7 +11,7 @@
     "prettier": "npx prettier --write ."
   },
   "dependencies": {
-    "lodash": "^4.17.21",
+    "lodash-es": "^4.17.21",
     "lottie-web": "^5.8.1"
   },
   "peerDependencies": {
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@babel/types": "7.21.0",
-    "@types/lodash": "4.14.191",
+    "@types/lodash-es": "4.17.6",
     "@types/node": "18.11.19",
     "@vitejs/plugin-vue": "2.3.4",
     "typescript": "4.9.5",

--- a/packages/vue3-lottie/src/vue3-lottie.vue
+++ b/packages/vue3-lottie/src/vue3-lottie.vue
@@ -11,7 +11,7 @@
 <script lang="ts">
 import { ref, onMounted, computed, watch, defineComponent, PropType } from 'vue'
 import Lottie from 'lottie-web'
-import { cloneDeep, isEqual } from 'lodash'
+import { cloneDeep, isEqual } from 'lodash-es'
 
 export interface LottieProps {
   animationData: any

--- a/packages/vue3-lottie/yarn.lock
+++ b/packages/vue3-lottie/yarn.lock
@@ -47,7 +47,14 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@types/lodash@4.14.191":
+"@types/lodash-es@4.17.6":
+  version "4.17.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash-es/-/lodash-es-4.17.6.tgz#c2ed4c8320ffa6f11b43eb89e9eaeec65966a0a0"
+  integrity sha512-R+zTeVUKDdfoRxpAryaQNRKk3105Rrgx2CFRClIgRGaqDTdjsm8h6IYA8ir584W3ePzkZfst5xIgDwYrlh9HLg==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
   version "4.14.191"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.191.tgz#09511e7f7cba275acd8b419ddac8da9a6a79e2fa"
   integrity sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==
@@ -499,10 +506,10 @@ jsonfile@^6.0.1:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
-lodash@^4.17.21:
+lodash-es@^4.17.21:
   version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
-  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
+  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
 
 lottie-web@^5.8.1:
   version "5.8.1"


### PR DESCRIPTION
This cuts down the build size from `217.21KiB` to `47.34KiB`!

Old

```
dist/style.css           0.22 KiB / gzip: 0.12 KiB
dist/vue3-lottie.es.js   217.21 KiB / gzip: 42.51 KiB
dist/vue3-lottie.umd.js   76.28 KiB / gzip: 27.78 KiB
```

New:

```
dist/style.css           0.22 KiB / gzip: 0.12 KiB
dist/vue3-lottie.es.js   47.34 KiB / gzip: 10.61 KiB
dist/vue3-lottie.umd.js   21.12 KiB / gzip: 7.65 KiB
```

If you would remove lodash completely, you would be looking at something like `9.78 KiB`. So that's definitely worth trying.