### PR TITLE
Update Nuxt 3 import examples.

### DIFF
--- a/docs/content/1.introduction/3.nuxt-3.md
+++ b/docs/content/1.introduction/3.nuxt-3.md
@@ -4,7 +4,7 @@
 If you upgrading from v2 to v3, please remove the `dist/style.css` import from your `app.vue` file. This css is now imported automatically by the plugin.
 ::
 
-## Register the component
+## Register the component globally
 
 1. Create a folder called **`plugins`** at the root of your project.
 
@@ -13,10 +13,10 @@ If you upgrading from v2 to v3, please remove the `dist/style.css` import from y
 3. Add the following code to the file:
 
    ```js
-   import Vue3Lottie from 'vue3-lottie'
+   import { Vue3Lottie } from 'vue3-lottie'
 
    export default defineNuxtPlugin((nuxtApp) => {
-     nuxtApp.vueApp.use(Vue3Lottie, { name: 'Vue3Lottie' })
+     nuxtApp.vueApp.component('Vue3Lottie', Vue3Lottie)
    })
    ```
 
@@ -25,9 +25,19 @@ If you upgrading from v2 to v3, please remove the `dist/style.css` import from y
    This should register a global component that you can call anywhere in your app under the `<Vue3Lottie>` tag. You can also change the name of the component by changing the `name` property in the plugin file.
    ::
 
+## Register the component locally
+
+The component can also simply be imported locally.
+
+   ```ts
+<script setup lang="ts">
+   import { Vue3Lottie } from 'vue3-lottie'
+</script>
+   ```
+
 ## Use the component
 
-Now you can use the component anywhere in your app. Here is an example of how to use it in a page.
+Now you can use the component. Here is an example of how to use it in a page.
 
 ::alert{type="warning"}
 Using the `<client-only>` tag is recommended to prevent any hydration errors.


### PR DESCRIPTION
In the global import example, VS Code was showing this error:

"Using exported name 'Vue3Lottie' as identifier for default export."

I updated the global plugin import to fix that.

I also added an example of how the component can be imported locally.