### PR TITLE
refactor: switch to smaller dependencies to reduce bundle size

### DIFF
--- a/packages/vue3-lottie/package.json
+++ b/packages/vue3-lottie/package.json
@@ -13,7 +13,8 @@
     "prettier": "npx prettier --write ."
   },
   "dependencies": {
-    "lodash-es": "^4.17.21",
+    "fast-deep-equal": "^3.1.3",
+    "klona": "^2.0.6",
     "lottie-web": "5.12.2"
   },
   "peerDependencies": {

--- a/packages/vue3-lottie/src/vue3-lottie.vue
+++ b/packages/vue3-lottie/src/vue3-lottie.vue
@@ -19,7 +19,8 @@ import {
   nextTick,
 } from 'vue'
 import Lottie from 'lottie-web'
-import { cloneDeep, isEqual } from 'lodash-es'
+import isEqual from 'fast-deep-equal/es6';
+import { klona as cloneDeep } from 'klona/json';
 
 import type {
   AnimationDirection,

--- a/packages/vue3-lottie/tsconfig.json
+++ b/packages/vue3-lottie/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "ESNext",
     "strict": true,
     "declaration": true,
+    "allowSyntheticDefaultImports": true,
     "lib": ["es2017", "ESNext", "DOM", "DOM.Iterable"],
     "jsx": "preserve",
     "outDir": "dist",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,9 +51,12 @@ importers:
 
   packages/vue3-lottie:
     dependencies:
-      lodash-es:
-        specifier: ^4.17.21
-        version: 4.17.21
+      fast-deep-equal:
+        specifier: ^3.1.3
+        version: 3.1.3
+      klona:
+        specifier: ^2.0.6
+        version: 2.0.6
       lottie-web:
         specifier: 5.12.2
         version: 5.12.2
@@ -3594,7 +3597,6 @@ packages:
 
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
-    dev: true
 
   /fast-fifo@1.3.2:
     resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
@@ -4339,7 +4341,6 @@ packages:
   /klona@2.0.6:
     resolution: {integrity: sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==}
     engines: {node: '>= 8'}
-    dev: true
 
   /knitwork@1.0.0:
     resolution: {integrity: sha512-dWl0Dbjm6Xm+kDxhPQJsCBTxrJzuGl0aP9rhr+TG8D3l+GL90N8O8lYUi7dTSAN2uuDqCtNgb6aEuQH5wsiV8Q==}
@@ -4403,10 +4404,6 @@ packages:
       mlly: 1.4.2
       pkg-types: 1.0.3
     dev: true
-
-  /lodash-es@4.17.21:
-    resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==}
-    dev: false
 
   /lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}


### PR DESCRIPTION
`fast-deep-equal` and `klona` serve as alternatives to `lodash-es`'s `isEqual` and `cloneDeep`, respectively. They offer more lightweight options that do not fall short in performance compared to `lodash-es`.

Here are the differences in bundle sizes before and after:

**Before**
```
dist/vue3-lottie.es.js   48.58 KiB / gzip: 10.85 KiB
dist/vue3-lottie.cjs.js   21.69 KiB / gzip: 7.66 KiB
```

**After**
```
dist/vue3-lottie.es.js   13.55 KiB / gzip: 3.32 KiB
dist/vue3-lottie.cjs.js   6.88 KiB / gzip: 2.54 KiB
```

All examples tested in the `playground` have been working normally. I am very open to understanding if there are any other considerations.