### PR TITLE
fix: ensure `loadLottie` is called after the component mounted

### DIFF
--- a/packages/vue3-lottie/src/vue3-lottie.vue
+++ b/packages/vue3-lottie/src/vue3-lottie.vue
@@ -16,7 +16,6 @@ import {
   defineComponent,
   PropType,
   watchEffect,
-  nextTick,
 } from 'vue'
 import Lottie from 'lottie-web'
 import { cloneDeep, isEqual } from 'lodash-es'
@@ -133,8 +132,6 @@ export default defineComponent({
           const responseJSON = await response.json()
 
           animationData.value = responseJSON
-
-          nextTick(() => loadLottie())
         } catch (error) {
           console.error(error)
           return
@@ -142,13 +139,13 @@ export default defineComponent({
       } else if (isEqual(props.animationData, {}) === false) {
         // clone the animationData to prevent it from being mutated
         animationData.value = cloneDeep(props.animationData)
-
-        nextTick(() => loadLottie())
       } else {
         throw new Error(
           'You must provide either animationLink or animationData',
         )
       }
+
+      loadLottie()
     })
 
     const loadLottie = () => {

--- a/packages/vue3-lottie/src/vue3-lottie.vue
+++ b/packages/vue3-lottie/src/vue3-lottie.vue
@@ -120,6 +120,10 @@ export default defineComponent({
     let direction: AnimationDirection = 1
 
     watchEffect(async () => {
+      // track and ensure that `lottieAnimationContainer` is mounted
+      // fix: #502
+      if(!lottieAnimationContainer.value) return
+
       if (props.animationLink != '') {
         // fetch the animation data from the url
 


### PR DESCRIPTION
Resolved #502 

Currently, `loadLottie` is invoked during the component's creation phase. However, this does not guarantee that the component will be mounted right away.

**App.vue**

```vue
<script setup lang="ts">
import { defineAsyncComponent } from 'vue';
const LazyDynamicComponent = defineAsyncComponent(() => import('./components/DynamicComponent.vue'));
</script>

<template>
    <Suspense>
      <LazyDynamicComponent />
    </Suspense>
</template>
```

**components/DynamicComponent.vue**

```vue
<template>
  <div>
    <Vue3Lottie :animationData="dog" :width="300" :height="300" />
  </div>
</template>

<script setup lang="ts">
import dog from '../assets/dog.json';

await new Promise(resolve => {
  setTimeout(() => {
    resolve(true);
  }, 3000);
});
</script>

```


Especially when we use `async setup()` with `<Suspense>`, the component will be created first but not mounted until the promise is resolved.

Therefore, it's essential to verify if the component has been mounted before calling `loadLottie`. We can do this by monitoring the `lottieAnimationContainer` value.