### PR TITLE
Bug: Updating typing of playSegments method

### DIFF
--- a/packages/vue3-lottie/src/vue3-lottie.vue
+++ b/packages/vue3-lottie/src/vue3-lottie.vue
@@ -412,7 +412,7 @@ export default defineComponent({
     }
 
     const playSegments = (
-      segments: AnimationSegment[],
+      segments: AnimationSegment | AnimationSegment[],
       forceFlag: boolean = false,
     ) => {
       //segments: array. Can contain 2 numeric values that will be used as first and last frame of the animation. Or can contain a sequence of arrays each with 2 numeric values.


### PR DESCRIPTION
The typing of playSegments is slightly off currently. So hereby a small PR to fix that :)

- expected usage according to docs: `[1, 10]` / `[[1, 10]]` / `[[1, 10], [11, 20], ... ]`
- actual usage according to typings: `[[1, 10], [11, 20]]` / `[[1, 10]]`

Both types work and are correct according to https://github.com/airbnb/lottie-web/blob/0d658b34c40d4e81eafdccbf698815346454a899/index.d.ts#L91

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Update the typing of the playSegments method to align with expected usage, allowing it to accept either a single AnimationSegment or an array of AnimationSegments.

Enhancements:
- Update the typing of the playSegments method to accept both a single AnimationSegment and an array of AnimationSegments.

<!-- Generated by sourcery-ai[bot]: end summary -->