### PR TITLE
Fix README for Nuxt3 users

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ yarn add vue3-lottie@latest
 import { Vue3Lottie } from 'vue3-lottie'
 
 export default defineNuxtPlugin((nuxtApp) => {
-  nuxtApp.vueApp.component('Vue3Lottie')
+  nuxtApp.vueApp.component('Vue3Lottie', Vue3Lottie)
 })
 ```
 


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Correct the Nuxt3 plugin registration example in the README to include the Vue3Lottie component.