### PR TITLE
fix: 3.nuxt-3.md nuxt3 plugin code error

### DIFF
--- a/docs/content/1.introduction/3.nuxt-3.md
+++ b/docs/content/1.introduction/3.nuxt-3.md
@@ -13,10 +13,10 @@ If you upgrading from v2 to v3, please remove the `dist/style.css` import from y
 3. Add the following code to the file:
 
    ```js
-   import { Vue3Lottie } from 'vue3-lottie'
-
+   import Vue3Lottie from 'vue3-lottie'
+   
    export default defineNuxtPlugin((nuxtApp) => {
-     nuxtApp.vueApp.component('Vue3Lottie', Vue3Lottie)
+     nuxtApp.vueApp.use(Vue3Lottie)
    })
    ```
 


### PR DESCRIPTION
when use below code to init plugin
```ts
import {Vue3Lottie} from 'vue3-lottie'

export default defineNuxtPlugin((nuxtApp) => {
  nuxtApp.vueApp.component('Vue3Lottie', Vue3Lottie)
})
```

it will throw error
```txt
 ERROR  [nuxt] [request error] [unhandled] [500] document is not defined
```
![image](https://github.com/user-attachments/assets/67adab26-c019-4883-ac49-cd8f9b1e16a9)
![image](https://github.com/user-attachments/assets/6f50c202-2050-4a47-9665-f9fca07a1bd7)


change this code to init, it works
```ts
import Vue3Lottie from 'vue3-lottie'

export default defineNuxtPlugin((nuxtApp) => {
  nuxtApp.vueApp.use(Vue3Lottie)
})
```

so need to change the doc

## Summary by Sourcery

Documentation:
- Correct the Nuxt 3 plugin initialization code example to use `use` instead of `component`.