### PR TITLE
fix: destroy should be called in onBeforeUnmount hook

### DIFF
--- a/packages/vue3-lottie/src/vue3-lottie.vue
+++ b/packages/vue3-lottie/src/vue3-lottie.vue
@@ -16,6 +16,7 @@ import {
   defineComponent,
   PropType,
   watchEffect,
+  onBeforeUnmount,
 } from 'vue'
 import Lottie from 'lottie-web'
 import isEqual from 'fast-deep-equal/es6';
@@ -443,6 +444,10 @@ export default defineComponent({
         )
       }
     }
+
+    onBeforeUnmount(() => {
+      destroy()
+    })
 
     return {
       lottieAnimationContainer,


### PR DESCRIPTION
I've experienced constant background activity in my app that have some lottie elements shown based on conditions many times during runtime which was tracked down to this library. And I guess this is because of missing destroy call in onBeforeUnmount hook. Otherwise the animation continues to live beyond the component existence and cumulatively consumes more and more resources each time a component is added and removed
![image](https://github.com/user-attachments/assets/47217120-9ef7-4dd9-9a6e-224e9545d047)

## Summary by Sourcery

Bug Fixes:
- Fixes a bug where the animation continues to run even after the component is unmounted, leading to resource consumption.